### PR TITLE
DEV: replace all biopython useage with cogent3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,8 @@ channels:
   - defaults
 dependencies:
   - python>=3.7.1
-  - biopython>=1.72
-  - python-igraph>=0.7.1
-  - cairocffi
+  - pip
+  - pip:
+    - cogent3
+    - cairocffi
+    - python-igraph>=0.7.1

--- a/graphbin_utils/graphbin_Canu.py
+++ b/graphbin_utils/graphbin_Canu.py
@@ -18,7 +18,7 @@ import subprocess
 import sys
 import time
 
-from Bio import SeqIO
+from cogent3.parse.fasta import MinimalFastaParser
 from igraph import *
 
 from graphbin_utils.bidirectionalmap.bidirectionalmap import BidirectionalMap
@@ -543,14 +543,14 @@ def run(args):
             output_bins_path + prefix + "bin_" + bin_name + ".fasta", "w+"
         )
 
-    for n, record in enumerate(SeqIO.parse(contigs_file, "fasta")):
+    for label, seq in MinimalFastaParser(
+        contigs_file, label_to_name=lambda x: x.split()[0]
+    ):
 
-        contig_num = contigs_map_rev[record.id]
+        contig_num = contigs_map_rev[label]
 
         if contig_num in final_bins:
-            bin_files[final_bins[contig_num]].write(
-                f">{str(record.description)}\n{str(record.seq)}\n"
-            )
+            bin_files[final_bins[contig_num]].write(f">{label}\n{seq}\n")
 
     # Close output files
     for c in set(final_bins.values()):

--- a/graphbin_utils/graphbin_Flye.py
+++ b/graphbin_utils/graphbin_Flye.py
@@ -18,7 +18,7 @@ import subprocess
 import sys
 import time
 
-from Bio import SeqIO
+from cogent3.parse.fasta import MinimalFastaParser
 from igraph import *
 
 from graphbin_utils.bidirectionalmap.bidirectionalmap import BidirectionalMap
@@ -641,14 +641,12 @@ def run(args):
             output_bins_path + prefix + "bin_" + bin_name + ".fasta", "w+"
         )
 
-    for n, record in enumerate(SeqIO.parse(contigs_file, "fasta")):
+    for label, seq in MinimalFastaParser(contigs_file):
 
-        contig_num = contig_names_rev[record.id]
+        contig_num = contig_names_rev[label]
 
         if contig_num in final_bins:
-            bin_files[final_bins[contig_num]].write(
-                f">{str(record.id)}\n{str(record.seq)}\n"
-            )
+            bin_files[final_bins[contig_num]].write(f">{label}\n{seq}\n")
 
     # Close output files
     for c in set(final_bins.values()):

--- a/graphbin_utils/graphbin_Miniasm.py
+++ b/graphbin_utils/graphbin_Miniasm.py
@@ -18,7 +18,7 @@ import subprocess
 import sys
 import time
 
-from Bio import SeqIO
+from cogent3.parse.fasta import MinimalFastaParser
 from igraph import *
 
 from graphbin_utils.bidirectionalmap.bidirectionalmap import BidirectionalMap
@@ -543,14 +543,12 @@ def run(args):
             output_bins_path + prefix + "bin_" + bin_name + ".fasta", "w+"
         )
 
-    for n, record in enumerate(SeqIO.parse(contigs_file, "fasta")):
+    for label, seq in MinimalFastaParser(contigs_file):
 
-        contig_num = contigs_map_rev[record.id]
+        contig_num = contigs_map_rev[label]
 
         if contig_num in final_bins:
-            bin_files[final_bins[contig_num]].write(
-                f">{str(record.id)}\n{str(record.seq)}\n"
-            )
+            bin_files[final_bins[contig_num]].write(f">{label}\n{seq}\n")
 
     # Close output files
     for c in set(final_bins.values()):

--- a/graphbin_utils/graphbin_SGA.py
+++ b/graphbin_utils/graphbin_SGA.py
@@ -19,7 +19,7 @@ import subprocess
 import sys
 import time
 
-from Bio import SeqIO
+from cogent3.parse.fasta import MinimalFastaParser
 from igraph import *
 
 from graphbin_utils.bidirectionalmap.bidirectionalmap import BidirectionalMap
@@ -123,8 +123,9 @@ def run(args):
 
     contig_descriptions = {}
 
-    for index, record in enumerate(SeqIO.parse(contigs_file, "fasta")):
-        contig_descriptions[record.id] = record.description
+    for label, _ in MinimalFastaParser(contigs_file):
+        name = label.split()[0]
+        contig_descriptions[name] = label
 
     # Get the links from the .asqg file
     # -----------------------------------
@@ -554,14 +555,14 @@ def run(args):
             output_bins_path + prefix + "bin_" + bin_name + ".fasta", "w+"
         )
 
-    for n, record in enumerate(SeqIO.parse(contigs_file, "fasta")):
+    for label, seq in MinimalFastaParser(
+        contigs_file, label_to_name=lambda x: x.split()[0]
+    ):
 
-        contig_num = contig_names_rev[record.id]
+        contig_num = contig_names_rev[label]
 
         if contig_num in final_bins:
-            bin_files[final_bins[contig_num]].write(
-                f">{str(record.description)}\n{str(record.seq)}\n"
-            )
+            bin_files[final_bins[contig_num]].write(f">{label}\n{seq}\n")
 
     # Close output files
     for c in set(final_bins.values()):

--- a/graphbin_utils/graphbin_SPAdes.py
+++ b/graphbin_utils/graphbin_SPAdes.py
@@ -20,7 +20,7 @@ import sys
 import time
 from collections import defaultdict
 
-from Bio import SeqIO
+from cogent3.parse.fasta import MinimalFastaParser
 from igraph import *
 
 from graphbin_utils.bidirectionalmap.bidirectionalmap import BidirectionalMap
@@ -614,14 +614,12 @@ def run(args):
             output_bins_path + prefix + "bin_" + bin_name + ".fasta", "w+"
         )
 
-    for n, record in enumerate(SeqIO.parse(contigs_file, "fasta")):
+    for label, seq in MinimalFastaParser(contigs_file):
 
-        contig_num = contig_names_rev[record.id]
+        contig_num = contig_names_rev[label]
 
         if contig_num in final_bins:
-            bin_files[final_bins[contig_num]].write(
-                f">{str(record.id)}\n{str(record.seq)}\n"
-            )
+            bin_files[final_bins[contig_num]].write(f">{label}\n{seq}\n")
 
     # Close output files
     for c in set(final_bins.values()):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-biopython>=1.72
+cogent3
 python-igraph>=0.7.1
 cairocffi

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
     ],
-    install_requires=["python-igraph", "biopython", "cairocffi", "setuptools"],
+    install_requires=["python-igraph", "cogent3", "cairocffi", "setuptools"],
     zip_safe=False,
 )

--- a/support/gfa2fasta.py
+++ b/support/gfa2fasta.py
@@ -11,9 +11,7 @@ import os
 import re
 import sys
 
-from Bio import SeqIO
-from Bio.Seq import Seq
-from Bio.SeqRecord import SeqRecord
+from cogent3 import make_unaligned_seqs
 
 __author__ = "Vijini Mallawaarachchi"
 __copyright__ = "Copyright 2019, GraphBin Project"
@@ -105,8 +103,7 @@ except:
 
 print("\nObtaining edge sequences")
 
-sequenceset = []
-
+sequences = {}
 with open(assembly_graph_file) as file:
 
     for line in file.readlines():
@@ -118,14 +115,7 @@ with open(assembly_graph_file) as file:
 
             print(strings)
 
-            record = SeqRecord(
-                Seq(re.sub("[^GATC]", "", str(strings[2]).upper())),
-                id=str(strings[1]),
-                name=str(strings[1]),
-                description="",
-            )
-
-            sequenceset.append(record)
+            sequences[str(strings[1])] = re.sub("[^GATC]", "", str(strings[2]).upper())
 
 print("\nWriting edge sequences to FASTA file")
 
@@ -134,8 +124,8 @@ if assembler.lower() == "flye":
 elif assembler.lower() == "miniasm":
     final_file = "unitigs.fasta"
 
-with open(output_path + prefix + final_file, "w") as output_handle:
-    SeqIO.write(sequenceset, output_handle, "fasta")
+sequences = make_unaligned_seqs(data=sequences)
+sequences.write(output_path + prefix + final_file)
 
 print(
     "\nThe FASTA file with",

--- a/support/prep_result.py
+++ b/support/prep_result.py
@@ -8,13 +8,14 @@ numbered starting from 1.
 
 """
 
+
 import argparse
 import csv
 import os
 import subprocess
 import sys
 
-from Bio import SeqIO
+from cogent3.parse.fasta import MinimalFastaParser
 
 __author__ = "Vijini Mallawaarachchi"
 __copyright__ = "Copyright 2019-2022, GraphBin Project"
@@ -161,15 +162,9 @@ for bin_file in files:
 
     if bin_file.lower().endswith((".fasta", ".fa", ".fna")):
 
-        for index, record in enumerate(
-            SeqIO.parse(contig_bins_folder + bin_file, "fasta")
-        ):
-            contig_name = str(record.id)
+        for contig_name, _ in MinimalFastaParser(contig_bins_folder + bin_file):
 
-            line = []
-            line.append(str(contig_name))
-
-            line.append(str(bin_file))
+            line = [contig_name, str(bin_file)]
             contig_bins.append(line)
 
 

--- a/support/visualise_result_MEGAHIT.py
+++ b/support/visualise_result_MEGAHIT.py
@@ -18,7 +18,7 @@ import subprocess
 import sys
 
 from bidirectionalmap.bidirectionalmap import BidirectionalMap
-from Bio import SeqIO
+from cogent3.parse.fasta import MinimalFastaParser
 from igraph import *
 
 __author__ = "Vijini Mallawaarachchi"
@@ -213,9 +213,10 @@ print("\nConstructing the assembly graph...")
 original_contigs = {}
 contig_descriptions = {}
 
-for index, record in enumerate(SeqIO.parse(contigs_file, "fasta")):
-    original_contigs[record.id] = str(record.seq)
-    contig_descriptions[record.id] = record.description
+for label, seq in MinimalFastaParser(contigs_file):
+    name = label.split()[0]
+    original_contigs[name] = seq
+    contig_descriptions[name] = label
 
 
 ## Construct the assembly graph


### PR DESCRIPTION
[CHANGED] the MinimalFastaParser just returns text objects corresponding to the
    the fasta label line and the sequence data.
[CHANGED] use the SequenceCollection class to output fasta formatted data. The
    write method on that class uses the filename suffix to determine the correct
    formatter.